### PR TITLE
Fix recursion caused by #8

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: heroku-php-apache2 / -l error.log
+web: heroku-php-apache2 -l error.log -v / 


### PR DESCRIPTION
```
2021-02-15T18:08:23.078933+00:00 app[web.1]: heroku-php-apache2: too many arguments. If you're using options,
2021-02-15T18:08:23.078934+00:00 app[web.1]: make sure to list them before any document root argument you're providing.
2021-02-15T18:08:23.078935+00:00 app[web.1]: 
2021-02-15T18:08:23.078935+00:00 app[web.1]: Usage:
2021-02-15T18:08:23.078935+00:00 app[web.1]:   heroku-php-apache2 [options] [<DOCUMENT_ROOT>]
2021-02-15T18:08:23.078936+00:00 app[web.1]: 
2021-02-15T18:08:23.078936+00:00 app[web.1]: Options:
2021-02-15T18:08:23.078936+00:00 app[web.1]:   -C <httpd.inc.conf>     The path to the configuration file to include inside
2021-02-15T18:08:23.078936+00:00 app[web.1]:                           the Apache2 VHost config (see option -c below). Will
2021-02-15T18:08:23.078936+00:00 app[web.1]:                           be included inside the '<VirtualHost>' section just
2021-02-15T18:08:23.078940+00:00 app[web.1]:                           after the '<Directory>' & 'ProxyPassMatch' directives.
2021-02-15T18:08:23.078940+00:00 app[web.1]:                           Recommended approach when customizing Apache2's config
2021-02-15T18:08:23.078940+00:00 app[web.1]:                           in most cases, unless you need to set fundamental
2021-02-15T18:08:23.078941+00:00 app[web.1]:                           server level options.
2021-02-15T18:08:23.078941+00:00 app[web.1]:                           [default: <BPDIR>/conf/apache2/default_include.conf,
2021-02-15T18:08:23.078941+00:00 app[web.1]:                           or a more version-specific file from a subdirectory]
2021-02-15T18:08:23.078941+00:00 app[web.1]:   -c <httpd.conf>         The path to the full VHost configuration file that is
2021-02-15T18:08:23.078941+00:00 app[web.1]:                           included after Heroku's (or your local) Apache2 config
2021-02-15T18:08:23.078942+00:00 app[web.1]:                           is loaded. Must contain a 'Listen ${PORT}' directive
2021-02-15T18:08:23.078942+00:00 app[web.1]:                           and should have a '<VirtualHost>' and likely also a
2021-02-15T18:08:23.078942+00:00 app[web.1]:                           '<Directory>' section (see option -C above).
2021-02-15T18:08:23.078942+00:00 app[web.1]:                           [default: <BPDIR>/conf/apache2/heroku.conf,
2021-02-15T18:08:23.078942+00:00 app[web.1]:                           or a more version-specific file from a subdirectory]
2021-02-15T18:08:23.078942+00:00 app[web.1]:   -F <php-fpm.inc.conf>   The path to the configuration file to include at the
2021-02-15T18:08:23.078943+00:00 app[web.1]:                           end of php-fpm.conf (see option -f below), in the
2021-02-15T18:08:23.078943+00:00 app[web.1]:                           '[www]' pool section. Recommended approach when
2021-02-15T18:08:23.078943+00:00 app[web.1]:                           customizing PHP-FPM's configuration in most cases,
2021-02-15T18:08:23.078943+00:00 app[web.1]:                           unless you need to set global options.
2021-02-15T18:08:23.078943+00:00 app[web.1]:   -f <php-fpm.conf>       The path to the full PHP-FPM configuration file.
2021-02-15T18:08:23.078943+00:00 app[web.1]:                           [default: <BPDIR>/conf/php/php-fpm.conf,
2021-02-15T18:08:23.078943+00:00 app[web.1]:                           or a more version-specific file from a subdirectory]
2021-02-15T18:08:23.078944+00:00 app[web.1]:   -h, --help              Display this help screen and exit.
2021-02-15T18:08:23.078944+00:00 app[web.1]:   -i <php.ini>            The path to the php.ini file to use.
2021-02-15T18:08:23.078944+00:00 app[web.1]:                           [default: <BPDIR>/conf/php/php.ini]
2021-02-15T18:08:23.078944+00:00 app[web.1]:   -l <tailme.log>         Path to additional log file to tail to STDERR so its
2021-02-15T18:08:23.078944+00:00 app[web.1]:                           contents appear in 'heroku logs'. If the file does not
2021-02-15T18:08:23.078945+00:00 app[web.1]:                           exist, it will be created. Wildcards are allowed, but
2021-02-15T18:08:23.078945+00:00 app[web.1]:                           must be quoted and must match already existing files.
2021-02-15T18:08:23.078945+00:00 app[web.1]:                           Note: this option can be repeated multiple times.
2021-02-15T18:08:23.078945+00:00 app[web.1]:   -p <PORT>               Port to listen on for HTTP traffic. If this argument
2021-02-15T18:08:23.078945+00:00 app[web.1]:                           is not given, then the port number to use is read from
2021-02-15T18:08:23.078945+00:00 app[web.1]:                           the $PORT environment variable, or a random port is
2021-02-15T18:08:23.078946+00:00 app[web.1]:                           chosen if that variable does not exist.
2021-02-15T18:08:23.078946+00:00 app[web.1]:   -v, --verbose           Be more verbose during startup.
2021-02-15T18:08:23.078946+00:00 app[web.1]: 
2021-02-15T18:08:23.078946+00:00 app[web.1]: The <BPDIR> placeholder above represents the base directory of this buildpack:
2021-02-15T18:08:23.078946+00:00 app[web.1]: /app/vendor/heroku/heroku-buildpack-php
2021-02-15T18:08:23.078946+00:00 app[web.1]: 
2021-02-15T18:08:23.078947+00:00 app[web.1]: All file paths must be relative to '/app'.
2021-02-15T18:08:23.078947+00:00 app[web.1]: 
2021-02-15T18:08:23.078947+00:00 app[web.1]: Any file name that ends in '.php' will be run through the PHP interpreter first.
2021-02-15T18:08:23.078947+00:00 app[web.1]: You may use this for templating although this is less useful than e.g. for Nginx
2021-02-15T18:08:23.078947+00:00 app[web.1]: where unlike in Apache2, you cannot reference environment variables in config
2021-02-15T18:08:23.078947+00:00 app[web.1]: files using a '${VARNAME}' syntax.
2021-02-15T18:08:23.078948+00:00 app[web.1]: 
2021-02-15T18:08:23.078948+00:00 app[web.1]: If you would like to use the -C and -c or -F and -f options together, make sure
2021-02-15T18:08:23.078948+00:00 app[web.1]: you retain the appropriate include mechanisms (see default configs for details).
```